### PR TITLE
Remove settings that are already defaults

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -22,8 +22,7 @@
     ],
     "css": [
       "compile/css/stackoverflow.css"
-    ],
-    "run_at": "document_idle"
+    ]
   }, {
     "matches": [
       "https://*.github.com/*"
@@ -34,8 +33,7 @@
     ],
     "css": [
       "compile/css/github.css"
-    ],
-    "run_at": "document_idle"
+    ]
   }, {
     "matches": [
       "https://www.npmjs.com/*"
@@ -46,8 +44,7 @@
     ],
     "css": [
       "compile/css/github.css"
-    ],
-    "run_at": "document_idle"
+    ]
   }],
   "background": {
     "scripts": [
@@ -68,7 +65,6 @@
   "permissions": [
     "tabs",
     "storage",
-    "http://stackoverflow.com/*",
     "clipboardWrite",
     "contextMenus"
   ],


### PR DESCRIPTION
Scripts already run at `document_idle` by default: https://developer.chrome.com/extensions/content_scripts#run_at

Also there's no need to specify hosts in the permissions if they are in `content_scripts` (as it already works with all the other hosts that aren't there)
